### PR TITLE
Update phila.gov url in alpha-alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
       <div data-swiftype-index="false" id="alpha-alert">
         <div class="row">
           <div class="large-18 columns">
-            <p>We're piloting a new, user-friendly website design. To view the existing City website, visit <a class="external" href="http://phila.gov" target="_blank">phila.gov<span class="accessible"> Opens in new window</span></a>.
+            <p>We're piloting a new, user-friendly website design. To view the existing City website, visit <a class="external" href="http://www.phila.gov" target="_blank">phila.gov<span class="accessible"> Opens in new window</span></a>.
           </div>
           <div class="large-6 columns accessibility">
             <i class="fa fa-globe"></i><div id="google_translate_element"></div>


### PR DESCRIPTION
Internal visitors need www in order to resolve properly.
